### PR TITLE
Add param query and location in extract_multiple_jobs function

### DIFF
--- a/custom_tools.py
+++ b/custom_tools.py
@@ -27,13 +27,14 @@ class JobScrapeQueryRun:
 
         return data
 
-    def extract_multiple_jobs(self):  # Add self as the first argument
+    def extract_multiple_jobs(self, query: str, location: str):  # Add self as the first argument
         params = {
             'api_key': self.api_key,
             'engine': 'google_jobs',
             'gl': 'us',
             'hl': 'en',
-            'q': 'barista new york',
+            'q': query,
+            'location': location,
         }
 
         search = GoogleSearch(params)


### PR DESCRIPTION
fix #1 agent error with log:

```
I encountered an error while trying to use the tool. This was the error: JobScrapeQueryRun.extract_multiple_jobs() takes 1 positional argument but 3 were given.
```